### PR TITLE
Stop transforming the request URI

### DIFF
--- a/metadata/version.go
+++ b/metadata/version.go
@@ -17,4 +17,4 @@
 package metadata
 
 // Version number string.
-const Version = "0.0.7"
+const Version = "0.0.8"

--- a/specs/swagger.go
+++ b/specs/swagger.go
@@ -185,7 +185,6 @@ func (s *Swagger) loadSubService(
 				Name:       subServiceName,
 				Properties: allProperties[subService],
 				Operations: operations,
-				//Service:    s.Data.Service,
 			}
 
 			if !strings.Contains(s.Data.Service.Name, "QingStor") {

--- a/specs/swagger_helpers.go
+++ b/specs/swagger_helpers.go
@@ -23,7 +23,6 @@ import (
 	"github.com/go-openapi/spec"
 
 	"github.com/yunify/snips/capsules"
-	"github.com/yunify/snips/utils"
 )
 
 func (s *Swagger) intermediateType(typeName, formatName string) string {
@@ -200,8 +199,6 @@ func (s *Swagger) parseOperation(
 	specOperation *spec.Operation, swagger *spec.Swagger) *capsules.Operation {
 
 	parsedURI := strings.Replace(uri, "?upload_id", "", -1)
-	parsedURI = utils.ReplaceCurlyBracketWithSquare(parsedURI)
-	parsedURI = utils.CamelCaseToDashConnected(parsedURI)
 
 	operation := &capsules.Operation{
 		ID:          specOperation.ID,


### PR DESCRIPTION
Previously we transform the request URI to lowercase and dash connected style, for example, "{bucketName}" -> "< bucket-name >". But it's better to respect the original API specs and do the transformation in code template.

Signed-off-by: Jingwen Peng <pengsrc@yunify.com>